### PR TITLE
Replace httptest::with_mock_API with with_mock_api

### DIFF
--- a/tests/testthat/helper_mock.R
+++ b/tests/testthat/helper_mock.R
@@ -30,10 +30,10 @@ if (nchar(redactor) && nchar(requester)) {
 if (ewr_mock_bypass == "capture") {
   message("Capturing mocks...")
   options(httptest.verbose = TRUE)
-  with_mock_API <- function(f) {
+  with_mock_api <- function(f) {
     httptest::capture_requests(f)
   }
 } else if (ewr_mock_bypass == "true" | !ewr_has_mocks) {
   message("Bypassing mocks...")
-  with_mock_API <- force
+  with_mock_api <- force
 }

--- a/tests/testthat/test_browse_edgar.R
+++ b/tests/testthat/test_browse_edgar.R
@@ -1,6 +1,6 @@
 context("running browse_edgar")
 
-with_mock_API({
+with_mock_api({
   test_that("running ", {
     expect_error(browse_edgar("EAR"),
                  "Could not find company: EAR")

--- a/tests/testthat/test_cik_search.R
+++ b/tests/testthat/test_cik_search.R
@@ -1,6 +1,6 @@
 context("running cik_search")
 
-with_mock_API({
+with_mock_api({
   test_that("One Result (Cloudera)", {
     res <- cik_search("cloudera")
 

--- a/tests/testthat/test_company_details.R
+++ b/tests/testthat/test_company_details.R
@@ -1,6 +1,6 @@
 context("running company_details")
 
-with_mock_API({
+with_mock_api({
   test_that("running", {
     expect_error(company_details("EAR"))
     res <- company_details("AAPL")

--- a/tests/testthat/test_company_filings.R
+++ b/tests/testthat/test_company_filings.R
@@ -1,6 +1,6 @@
 context("running company_filings")
 
-with_mock_API({
+with_mock_api({
 test_that("running", {
   expect_error(company_filings("EAR"))
   res <- company_filings("AAPL")

--- a/tests/testthat/test_company_information.R
+++ b/tests/testthat/test_company_information.R
@@ -1,6 +1,6 @@
 context("running company_information")
 
-with_mock_API({
+with_mock_api({
 test_that("running ", {
             expect_error(company_information("EAR"))
             res <- company_information("EA")

--- a/tests/testthat/test_company_search.R
+++ b/tests/testthat/test_company_search.R
@@ -1,6 +1,6 @@
 context("running company_search")
 
-with_mock_API({
+with_mock_api({
   test_that("Multipe Results", {
     res <- company_search("delhaize")
     expect_length(res, 19)

--- a/tests/testthat/test_current_events.R
+++ b/tests/testthat/test_current_events.R
@@ -1,6 +1,6 @@
 context("running current_events")
 
-with_mock_API({
+with_mock_api({
   test_that("Basic Search", {
     res <- current_events(0, "10-K")
 

--- a/tests/testthat/test_effectiveness.R
+++ b/tests/testthat/test_effectiveness.R
@@ -1,6 +1,6 @@
 context("running effectiveness")
 
-with_mock_API({
+with_mock_api({
   test_that("running ", {
     res <- effectiveness()
     expect_length(res, 8)

--- a/tests/testthat/test_filing_details.R
+++ b/tests/testthat/test_filing_details.R
@@ -1,6 +1,6 @@
 context("running filing_details")
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 4)", {
     href <- "https://www.sec.gov/Archives/edgar/data/1333712/000156218017002633/0001562180-17-002633-index.htm"
     res <- filing_details(href)

--- a/tests/testthat/test_filing_documents.R
+++ b/tests/testthat/test_filing_documents.R
@@ -1,6 +1,6 @@
 context("running filing_documents")
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 4)", {
     href <- "https://www.sec.gov/Archives/edgar/data/1333712/000156218017002633/0001562180-17-002633-index.htm"
     res <- filing_documents(href)

--- a/tests/testthat/test_filing_filers.R
+++ b/tests/testthat/test_filing_filers.R
@@ -3,7 +3,7 @@ context("running filing_filers")
 # The XPath for filing_filers is particularly complex, so it is particularly
 # important to test a wide range of values
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 4)", {
     href <- "https://www.sec.gov/Archives/edgar/data/1333712/000156218017002633/0001562180-17-002633-index.htm"
     res <- filing_filers(href)

--- a/tests/testthat/test_filing_funds.R
+++ b/tests/testthat/test_filing_funds.R
@@ -1,6 +1,6 @@
 context("running filing_funds")
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 485APOS)", {
     href <- "https://www.sec.gov/Archives/edgar/data/933691/000093369117000309/0000933691-17-000309-index.htm"
     res <- filing_funds(href)

--- a/tests/testthat/test_filing_information.R
+++ b/tests/testthat/test_filing_information.R
@@ -1,6 +1,6 @@
 context("running filing_information")
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 4)", {
     href <- "https://www.sec.gov/Archives/edgar/data/1333712/000156218017002633/0001562180-17-002633-index.htm"
     res <- filing_information(href)

--- a/tests/testthat/test_full_text.R
+++ b/tests/testthat/test_full_text.R
@@ -1,6 +1,6 @@
 context("running full_text")
 
-with_mock_API({
+with_mock_api({
   test_that("basic search", {
     res <- full_text("intel")
     expect_length(res, 9)

--- a/tests/testthat/test_fund_search.R
+++ b/tests/testthat/test_fund_search.R
@@ -1,6 +1,6 @@
 context("running fund_search")
 
-with_mock_API({
+with_mock_api({
   test_that("running", {
     res <- fund_search("precious metals")
     expect_is(res, "data.frame")

--- a/tests/testthat/test_header_search.R
+++ b/tests/testthat/test_header_search.R
@@ -1,6 +1,6 @@
 context("running header_search")
 
-with_mock_API({
+with_mock_api({
   test_that("basic search", {
     res <- header_search("company-name = Apple")
     expect_length(res, 5)

--- a/tests/testthat/test_latest_filings.R
+++ b/tests/testthat/test_latest_filings.R
@@ -1,6 +1,6 @@
 context("running latest_filings")
 
-with_mock_API({
+with_mock_api({
   test_that("basics", {
     res <- latest_filings()
     expect_length(res, 9)

--- a/tests/testthat/test_parse_filing.R
+++ b/tests/testthat/test_parse_filing.R
@@ -46,7 +46,7 @@ test_filing <- function(file.name, rows, parts, items, is_dev = TRUE) {
   res
 }
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 10-Q)", {
     skip_on_cran()
     # "https://www.sec.gov/Archives/edgar/data/712515/000071251517000010/ea12312016-q3fy1710qdoc.htm"

--- a/tests/testthat/test_parse_submission.R
+++ b/tests/testthat/test_parse_submission.R
@@ -3,7 +3,7 @@ context("running parse_submission")
 # The XPath for filing_filers is particularly complex, so it is particularly
 # important to test a wide range of values
 
-with_mock_API({
+with_mock_api({
   test_that("Basics (type 8-K)", {
     href <- "https://www.sec.gov/Archives/edgar/data/37996/000003799617000084/0000037996-17-000084.txt"
     res <- parse_submission(href)

--- a/tests/testthat/test_parse_text_filing.R
+++ b/tests/testthat/test_parse_text_filing.R
@@ -1,6 +1,6 @@
 context("running parse_text_filing")
 
-with_mock_API({
+with_mock_api({
   test_that("Ford 10-K", {
     href <-
       "https://www.sec.gov/Archives/edgar/data/37996/000003799602000015/v7.txt"

--- a/tests/testthat/test_variable_insurance_search.R
+++ b/tests/testthat/test_variable_insurance_search.R
@@ -1,6 +1,6 @@
 context("running variable_insurance_search")
 
-with_mock_API({
+with_mock_api({
   test_that("running", {
     res <- variable_insurance_search("precious metals")
     expect_is(res, "data.frame")


### PR DESCRIPTION
Three years ago, [several functions were renamed](https://enpiar.com/r/httptest/news/#other-big-changes-and-enhancements) in the `httptest` 3.0.0 release for consistency with `httr` and `testthat`. Function aliases with the old naming were kept to avoid breaking packages, but in the [upcoming `httptest` 4.0.0 release](https://github.com/nealrichardson/httptest/issues/53), these deprecated functions are being removed. This PR updates your package to use the functions that will remain in the 4.0.0 release.

We plan to submit the `httptest` update to CRAN at the end of January. To avoid any potential nastygrams from CRAN, it would be ideal if you can update your package on CRAN with this change before then. Thanks!